### PR TITLE
GH Actions: don't run the "update readme" workflow on forks

### DIFF
--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -14,7 +14,7 @@ jobs:
   regenerate-readme: #----------------------------------------------------------
     name: Regenerate README.md file
     runs-on: ubuntu-latest
-    if: ${{ ! contains(fromJson('[".github", "wp-cli", "wp-cli-bundle", "wp-super-cache-cli", "php-cli-tools", "wp-config-transformer"]'), github.event.repository.name) }}
+    if: ${{ github.repository_owner == 'wp-cli' && ! contains(fromJson('[".github", "wp-cli", "wp-cli-bundle", "wp-super-cache-cli", "php-cli-tools", "wp-config-transformer"]'), github.event.repository.name) }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v2


### PR DESCRIPTION
Based on https://github.com/wp-cli/scaffold-command/pull/296