### PR TITLE
GHA  auto-cancel previous builds

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - master
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lint: #-----------------------------------------------------------------------

--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -8,6 +8,13 @@ on:
     paths-ignore:
       - 'features/**'
       - 'README.md'
+      
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 
 jobs:
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - master
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
 
   unit: #-----------------------------------------------------------------------


### PR DESCRIPTION
See https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/