### PR TITLE
Switch reusable workflows to `@main` instead of a hash

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   code-quality:
-    uses: wp-cli/.github/.github/workflows/reusable-code-quality.yml@85be2d1b154ddf1b2f03166c93bc75a27fb3daf1
+    uses: wp-cli/.github/.github/workflows/reusable-code-quality.yml@main

--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   regenerate-readme:
-    uses: wp-cli/.github/.github/workflows/reusable-regenerate-readme.yml@85be2d1b154ddf1b2f03166c93bc75a27fb3daf1
+    uses: wp-cli/.github/.github/workflows/reusable-regenerate-readme.yml@main

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   test:
-    uses: wp-cli/.github/.github/workflows/reusable-testing.yml@85be2d1b154ddf1b2f03166c93bc75a27fb3daf1
+    uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main


### PR DESCRIPTION
Seems to work fine https://github.com/wp-cli/reusable-workflow-test/pull/1/commits/b1dbde60b576665b84e539af4b4ab267a8ece214

From #35
Related #34