### PR TITLE
Remove "Are you in the right destination?" HTML comment in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/1-BUG_REPORT.md
@@ -9,48 +9,6 @@ assignees: ''
 
 ## Bug Report
 
-<!--- ⚠️ Before you start reporting the bug... ---
-
-**Is your bug report directly related to a specific command?**
-
-If yes, make sure you are in the correct repository that contains the command you are referring to, and only create the issue in that repository.
-
-Here's a quick overview of where to find the different commands:
-
-* `wp (cache|transient) *` https://github.com/wp-cli/cache-command
-* `wp checksum` https://github.com/wp-cli/checksum-command
-* `wp config *` https://github.com/wp-cli/config-command
-* `wp core *` https://github.com/wp-cli/core-command
-* `wp cron *` https://github.com/wp-cli/cron-command
-* `wp db *` https://github.com/wp-cli/db-command
-* `wp embed *` https://github.com/wp-cli/embed-command
-* `wp (eval|eval-file)` https://github.com/wp-cli/eval-command
-* `wp export` https://github.com/wp-cli/export-command
-* `wp (option|post|comment|user|term|site) *` https://github.com/wp-cli/entity-command
-* `wp i18n` https://github.com/wp-cli/i18n-command
-* `wp import` https://github.com/wp-cli/import-command
-* `wp language` https://github.com/wp-cli/language-command
-* `wp maintenance-mode *` https://github.com/wp-cli/maintenance-mode-command
-* `wp media *` https://github.com/wp-cli/media-command
-* `wp package *` https://github.com/wp-cli/package-command
-* `wp (plugin|theme) *` https://github.com/wp-cli/extension-command
-* `wp rewrite` https://github.com/wp-cli/rewrite-command
-* `wp (role|cap) *` https://github.com/wp-cli/role-command
-* `wp scaffold *` https://github.com/wp-cli/scaffold-command
-* `wp search-replace` https://github.com/wp-cli/search-replace-command
-* `wp server` https://github.com/wp-cli/server-command
-* `wp shell` https://github.com/wp-cli/shell-command
-* `wp super-admin *` https://github.com/wp-cli/super-admin-command
-* `wp (widget|sidebar) *` https://github.com/wp-cli/widget-command
-
-If you are not in the correct repository right now, you can just close this issue/window without submitting and click through to the correct one.
-
-**Are you unsure about what repository to post the bug report into?**
-
-Just head over to the [`wp-cli/wp-cli`](https://github.com/wp-cli/wp-cli) repository and [create a new issue in that repository](https://github.com/wp-cli/wp-cli/issues/new). The maintainers can still move the bug report into the correct repository later on.
-
---- ✅ If you are in the correct location now... --->
-
 - [ ] Yes, I reviewed the [contribution guidelines](https://make.wordpress.org/cli/handbook/contributing/).
 - [ ] Yes, more specifically, I reviewed the guidelines on [how to write clear bug reports](https://make.wordpress.org/cli/handbook/bug-reports/).
 

--- a/.github/ISSUE_TEMPLATE/2-FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/2-FEATURE_REQUEST.md
@@ -9,50 +9,6 @@ assignees: ''
 
 ## Feature Request
 
-<!--- ⚠️ Before you describe your requested feature... ---
-
-**Is your feature request directly related to a specific, existing command?**
-
-If yes, make sure you are in the correct repository that contains the command you are referring to, and only create the issue in that repository.
-
-Here's a quick overview of where to find the different commands:
-
-* `wp (cache|transient) *` https://github.com/wp-cli/cache-command
-* `wp checksum` https://github.com/wp-cli/checksum-command
-* `wp config *` https://github.com/wp-cli/config-command
-* `wp core *` https://github.com/wp-cli/core-command
-* `wp cron *` https://github.com/wp-cli/cron-command
-* `wp db *` https://github.com/wp-cli/db-command
-* `wp embed *` https://github.com/wp-cli/embed-command
-* `wp (eval|eval-file)` https://github.com/wp-cli/eval-command
-* `wp export` https://github.com/wp-cli/export-command
-* `wp (option|post|comment|user|term|site) *` https://github.com/wp-cli/entity-command
-* `wp i18n` https://github.com/wp-cli/i18n-command
-* `wp import` https://github.com/wp-cli/import-command
-* `wp language` https://github.com/wp-cli/language-command
-* `wp maintenance-mode *` https://github.com/wp-cli/maintenance-mode-command
-* `wp media *` https://github.com/wp-cli/media-command
-* `wp package *` https://github.com/wp-cli/package-command
-* `wp (plugin|theme) *` https://github.com/wp-cli/extension-command
-* `wp rewrite` https://github.com/wp-cli/rewrite-command
-* `wp (role|cap) *` https://github.com/wp-cli/role-command
-* `wp scaffold *` https://github.com/wp-cli/scaffold-command
-* `wp search-replace` https://github.com/wp-cli/search-replace-command
-* `wp server` https://github.com/wp-cli/server-command
-* `wp shell` https://github.com/wp-cli/shell-command
-* `wp super-admin *` https://github.com/wp-cli/super-admin-command
-* `wp (widget|sidebar) *` https://github.com/wp-cli/widget-command
-
-If you are not in the correct repository right now, you can just close this issue/window without submitting and click through to the correct one.
-
-**Is your feature request about a new command, or a more general idea?**
-
-If your feature request is not about making a change to one or more existing commands, but rather about adding functionality that doesn't naturally fit one of the existing commands, head over to the [`wp-cli/ideas`](https://github.com/wp-cli/ideas) repository and [create a new issue in that repository](https://github.com/wp-cli/ideas/issues/new).
-
-The issue tracker in that repository will collect ideas that are still vague and need fleshing out and/or preparatory work (like creating a new repository) before the actual development work can begin.
-
---- ✅ If you are in the correct location now... ---> 
-
 - [ ] Yes, I reviewed the [contribution guidelines](https://make.wordpress.org/cli/handbook/contributing/).
 
 **Describe your use case and the problem you are facing**


### PR DESCRIPTION
It's pretty easy to move issues between repos these days, so we don't need to put this on the user.