### PR TITLE
Pass `GITHUB_TOKEN` to the reusable workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   code-quality:
     uses: wp-cli/.github/.github/workflows/reusable-code-quality.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -13,3 +13,5 @@ on:
 jobs:
   regenerate-readme:
     uses: wp-cli/.github/.github/workflows/reusable-regenerate-readme.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,3 +12,5 @@ on:
 jobs:
   test:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It's used in some of the workflows, and they break without it

From https://github.com/wp-cli/package-command/pull/164
See https://github.com/wp-cli/wp-cli/issues/5720