### PR TITLE
Allow `GITHUB_TOKEN` to be passed into the reusable workflow

### DIFF
--- a/.github/workflows/reusable-code-quality.yml
+++ b/.github/workflows/reusable-code-quality.yml
@@ -2,6 +2,10 @@ name: Code Quality Checks
 
 on:
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        description: 'GitHub token used to authorize requests'
+        required: true
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:

--- a/.github/workflows/reusable-regenerate-readme.yml
+++ b/.github/workflows/reusable-regenerate-readme.yml
@@ -2,6 +2,10 @@ name: Regenerate README file
 
 on:
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        description: 'GitHub token used to authorize requests'
+        required: true
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -2,6 +2,10 @@ name: Testing
 
 on:
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        description: 'GitHub token used to authorize requests'
+        required: true
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:


### PR DESCRIPTION
From https://github.com/wp-cli/.github/pull/48