### PR TITLE
Revert "Pass `GITHUB_TOKEN` to the reusable workflow"

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,5 +10,3 @@ on:
 jobs:
   code-quality:
     uses: wp-cli/.github/.github/workflows/reusable-code-quality.yml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -13,5 +13,3 @@ on:
 jobs:
   regenerate-readme:
     uses: wp-cli/.github/.github/workflows/reusable-regenerate-readme.yml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,5 +12,3 @@ on:
 jobs:
   test:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts wp-cli/.github#48
See https://github.com/wp-cli/wp-cli/issues/5720

It breaks all of the tests 😔 https://wordpress.slack.com/archives/C02RP4T41/p1673464502434829