### PR TITLE
Run trunk tests on PHP 7.0+

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -76,13 +76,13 @@ jobs:
         wp: ['latest']
         mysql: ['8.0']
         include:
-          - php: '5.6'
+          - php: '7.0'
             wp: 'trunk'
             mysql: '8.0'
-          - php: '5.6'
+          - php: '7.0'
             wp: 'trunk'
             mysql: '5.7'
-          - php: '5.6'
+          - php: '7.0'
             wp: 'trunk'
             mysql: '5.6'
           - php: '7.4'

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -106,6 +106,9 @@ jobs:
           - php: '5.6'
             wp: '3.7'
             mysql: '5.6'
+          - php: '5.6'
+            wp: '6.2'
+            mysql: '8.0'
     runs-on: ubuntu-20.04
 
     services:


### PR DESCRIPTION
Trunk bumped the PHP version requirement to 7.0+, see https://make.wordpress.org/core/2023/07/05/dropping-support-for-php-5/

Once 6.3 is released we'll also need to remove the latest+5.6 combo