### PR TITLE
GHA/reusable-testing: start running the tests against PHP 8.3

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -16,8 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     runs-on: ubuntu-20.04
+
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     steps:
       - name: Check out source code
@@ -109,7 +111,12 @@ jobs:
           - php: '5.6'
             wp: '6.2'
             mysql: '8.0'
+          - php: '8.3'
+            wp: 'trunk'
+            mysql: '8.0'
     runs-on: ubuntu-20.04
+
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     services:
       mysql:


### PR DESCRIPTION
PHP 8.3 is nearing the RC phase. As WP-CLI is used in the build processes of plenty of other WP packages, I believe it would be beneficial to start supporting PHP 8.3 officially sooner rather than later.

This commit adds PHP 8.3 to the build matrix to start running the tests against PHP 8.3.

Note: I'm not sure how to test the workflow as things are, so I hope I've done it correctly. I've also opened a PR in the Behat repo to start running their tests against PHP 8.3 (Behat/Behat#1440) and their build currently passes, so I expect that the tooling used should all work on PHP 8.3.

Having said that, whether PHP 8.3 can be supported without any fixes will need to be evaluated individually for each WP-CLI repo, so for now, I've added a `continue-on-error` for PHP 8.3 to be on the safe side.