### PR TITLE
Remove deleted repo from sync workflow

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -57,7 +57,6 @@ jobs:
             wp-cli/search-replace-command
             wp-cli/server-command
             wp-cli/shell-command
-            wp-cli/snapshot-command
             wp-cli/super-admin-command
             wp-cli/widget-command
             wp-cli/wp-cli


### PR DESCRIPTION
The sync workflow currently fails because of this