### PR TITLE
Compare matrix<->Composer versions, maybe exit

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -45,7 +45,7 @@ jobs:
           echo "COMPOSER_PHP_VERSION=$(jq '.require.php' composer.json | sed 's/[^0-9.|]//g' | jq -Rc 'split("|") | min | tonumber')" >> $GITHUB_OUTPUT;
 
       - name: Exit early if matrix PHP version lower than composer.json required PHP version
-        run: if [[ $(bc -l <<< "$COMPOSER_PHP_VERSION > $MATRIX_PHP_VERSION") -eq 1 ]]; then exit -1; fi
+        run: if [[ $(bc -l <<< "$COMPOSER_PHP_VERSION > $MATRIX_PHP_VERSION") -eq 1 ]]; then exit 1; fi
         env:
           COMPOSER_PHP_VERSION: ${{ steps.parse-composer.outputs.COMPOSER_PHP_VERSION }}
           MATRIX_PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get composer.json PHP version
         id: parse-composer
         run: |
-          echo "COMPOSER_PHP_VERSION=$(jq '.require.php' composer.json | sed 's/[^0-9.|]//g' | jq -Rc 'split("|") | min | tonumber')" >> $GITHUB_OUTPUT;
+          echo "COMPOSER_PHP_VERSION=$(jq '.require.php' composer.json | sed 's/[^0-9.|]//g' | jq -Rc 'split("|") | min // '5.6' | tonumber')" >> $GITHUB_OUTPUT;
 
       - name: Exit early if matrix PHP version lower than composer.json required PHP version
         run: if [[ $(bc -l <<< "$COMPOSER_PHP_VERSION > $MATRIX_PHP_VERSION") -eq 1 ]]; then exit 1; fi

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -39,6 +39,17 @@ jobs:
         with:
           files: "composer.json, phpunit.xml.dist"
 
+      - name: Get composer.json PHP version
+        id: parse-composer
+        run: |
+          echo "COMPOSER_PHP_VERSION=$(jq '.require.php' composer.json | sed 's/[^0-9.|]//g' | jq -Rc 'split("|") | min | tonumber')" >> $GITHUB_OUTPUT;
+
+      - name: Exit early if matrix PHP version lower than composer.json required PHP version
+        run: if [[ $(bc -l <<< "$COMPOSER_PHP_VERSION > $MATRIX_PHP_VERSION") -eq 1 ]]; then exit -1; fi
+        env:
+          COMPOSER_PHP_VERSION: ${{ steps.parse-composer.outputs.COMPOSER_PHP_VERSION }}
+          MATRIX_PHP_VERSION: ${{ matrix.php }}
+
       - name: Set up PHP environment (PHP 5.6 - 7.1)
         if: ${{ matrix.php >= inputs.minimum-php && matrix.php < '7.2' && steps.check_files.outputs.files_exists == 'true'}}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -29,7 +29,6 @@ jobs:
 
     steps:
       - name: Check out source code
-        if: ${{ matrix.php >= inputs.minimum-php }}
         uses: actions/checkout@v4
 
       - name: Check existence of composer.json file


### PR DESCRIPTION
This exits a workflow run (i.e. an instance of a matrix run) if the PHP version in `composer.json` is higher than the matrix's PHP version.

I'm not certain what the result will say on the PR runs – the overall workflow has a "success" green tick, and the individual skipped runs have the red failure x. The failure email does _not_ get sent.

That might not work exactly as desired, but there doesn't seem to be [an early-exit command](https://github.com/actions/runner/issues/662) – note the 750+ likes for that feature request! The [REST API](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#cancel-a-workflow-run) and `gh run cancel` use `github.run_id` which is the workflow id rather than `github.run_number` which is the matrix run instance, so cancelling the PHP 5.6 run cancels all of them.

<img width="478" alt="Screenshot 2023-09-26 at 1 09 37 PM" src="https://github.com/wp-cli/.github/assets/4720401/206da26f-2a88-4bd0-9635-80225ec4e513">
<img width="351" alt="Screenshot 2023-09-26 at 1 09 04 PM" src="https://github.com/wp-cli/.github/assets/4720401/5cafe82c-d35b-4b88-ac90-9b7625876cd6">
