### PR TITLE
Add GHA workflow validation

### DIFF
--- a/.github/workflows/reusable-code-quality.yml
+++ b/.github/workflows/reusable-code-quality.yml
@@ -93,3 +93,21 @@ jobs:
       - name: Run PHPCS
         if: steps.check_phpcs_binary_file.outputs.files_exists == 'true'
         run: vendor/bin/phpcs -q --report=checkstyle | cs2pr
+
+  actions: #----------------------------------------------------------------------
+    name: Validate GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install action-validator with asdf
+        uses: asdf-vm/actions/install@v2
+        with:
+          tool_versions: |
+            action-validator latest
+
+      - name: Validate Actions
+        run: |
+          find .github/workflows -type f \( -iname \*.yaml -o -iname \*.yml \) \
+            | xargs -I {} action-validator --verbose {}


### PR DESCRIPTION
Use the [Action Validator](https://github.com/mpalmer/action-validator) to do some initial smoke testing of the GitHub Actions workflows.