### PR TITLE
Dynamically create test matrix, take 2

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -16,31 +16,209 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-matrix:
+    name: Get base test matrix
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.base-matrix.outputs.matrix }}
+    steps:
+    - name: Set matrix
+      id: base-matrix
+      run: |
+        MATRIX=$(cat << EOF
+        {
+          "include": [
+            {
+              "php": "7.0",
+              "wp": "latest",
+              "mysql": "8.0"
+            },
+            {
+              "php": "7.0",
+              "wp": "latest",
+              "dbtype": "sqlite"
+            },
+            {
+              "php": "7.1",
+              "wp": "latest",
+              "mysql": "8.0"
+            },
+            {
+              "php": "7.1",
+              "wp": "latest",
+              "dbtype": "sqlite"
+            },
+            {
+              "php": "7.2",
+              "wp": "latest",
+              "mysql": "8.0"
+            },
+            {
+              "php": "7.2",
+              "wp": "latest",
+              "dbtype": "sqlite"
+            },
+            {
+              "php": "7.3",
+              "wp": "latest",
+              "mysql": "8.0"
+            },
+            {
+              "php": "7.3",
+              "wp": "latest",
+              "dbtype": "sqlite"
+            },
+            {
+              "php": "7.4",
+              "wp": "latest",
+              "mysql": "8.0"
+            },
+            {
+              "php": "7.4",
+              "wp": "latest",
+              "dbtype": "sqlite"
+            },
+            {
+              "php": "8.0",
+              "wp": "latest",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.0",
+              "wp": "latest",
+              "dbtype": "sqlite"
+            },
+            {
+              "php": "8.1",
+              "wp": "latest",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.1",
+              "wp": "latest",
+              "dbtype": "sqlite"
+            },
+            {
+              "php": "8.2",
+              "wp": "latest",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.2",
+              "wp": "latest",
+              "dbtype": "sqlite"
+            },
+            {
+              "php": "7.0",
+              "wp": "trunk",
+              "mysql": "8.0"
+            },
+            {
+              "php": "7.0",
+              "wp": "trunk",
+              "mysql": "5.7"
+            },
+            {
+              "php": "7.0",
+              "wp": "trunk",
+              "mysql": "5.6"
+            },
+            {
+              "php": "7.4",
+              "wp": "trunk",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.0",
+              "wp": "trunk",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.0",
+              "wp": "trunk",
+              "mysql": "5.7"
+            },
+            {
+              "php": "8.0",
+              "wp": "trunk",
+              "mysql": "5.6"
+            },
+            {
+              "php": "8.1",
+              "wp": "trunk",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.2",
+              "wp": "trunk",
+              "mysql": "8.0"
+            },
+            {
+              "php": "5.6",
+              "wp": "3.7",
+              "mysql": "5.6"
+            },
+            {
+              "php": "5.6",
+              "wp": "6.2",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.3",
+              "wp": "trunk",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.2",
+              "wp": "trunk",
+              "dbtype": "sqlite"
+            },
+            {
+              "php": "8.3",
+              "wp": "trunk",
+              "dbtype": "sqlite"
+            }
+          ]
+        }
+        EOF
+        )
+        echo matrix=$MATRIX >> $GITHUB_OUTPUT
+
+  prepare-unit:
+    name: Prepare matrix for unit tests
+    needs: get-matrix
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: echo "matrix=$(jq -c '.include |= map(with_entries(select(.key == "php"))) | .include |= map(select(.php >= "${{ inputs.minimum-php }}"))' <<< $BASE_MATRIX)" >> $GITHUB_OUTPUT
+        env:
+          BASE_MATRIX: ${{ needs.get-matrix.outputs.matrix }}
 
   unit: #-----------------------------------------------------------------------
     name: Unit test /  PHP ${{ matrix.php }}
+    needs: prepare-unit
     strategy:
       fail-fast: false
-      matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+      matrix: ${{ fromJson(needs.prepare-unit.outputs.matrix) }}
     runs-on: ubuntu-20.04
 
     continue-on-error: ${{ matrix.php == '8.3' }}
 
     steps:
       - name: Check out source code
-        if: ${{ matrix.php >= inputs.minimum-php }}
         uses: actions/checkout@v4
 
       - name: Check existence of composer.json file
-        if: ${{ matrix.php >= inputs.minimum-php }}
         id: check_files
         uses: andstor/file-existence-action@v2
         with:
           files: "composer.json, phpunit.xml.dist"
 
       - name: Set up PHP environment (PHP 5.6 - 7.1)
-        if: ${{ matrix.php >= inputs.minimum-php && matrix.php < '7.2' && steps.check_files.outputs.files_exists == 'true'}}
+        if: ${{ matrix.php < '7.2' && steps.check_files.outputs.files_exists == 'true'}}
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
@@ -51,7 +229,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up PHP environment (PHP 7.2+)
-        if: ${{ matrix.php >= inputs.minimum-php && matrix.php >= '7.2' && steps.check_files.outputs.files_exists == 'true'}}
+        if: ${{ matrix.php >= '7.2' && steps.check_files.outputs.files_exists == 'true'}}
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
@@ -61,7 +239,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies & cache dependencies
-        if: ${{ matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         uses: "ramsey/composer-install@v2"
         env:
           COMPOSER_ROOT_VERSION: dev-${{ github.event.repository.default_branch }}
@@ -70,62 +248,32 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Setup problem matcher to provide annotations for PHPUnit
-        if: ${{ matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Run PHPUnit
-        if: ${{ matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         run: composer phpunit
 
-  functional: #----------------------------------------------------------------------
+  prepare-functional: #---------------------------------------------------------
+    name: Prepare matrix for functional tests
+    needs: get-matrix
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: echo "matrix=$(jq -c '.include |= map(select(.php >= "${{ inputs.minimum-php }}"))' <<< $BASE_MATRIX)" >> $GITHUB_OUTPUT
+        env:
+          BASE_MATRIX: ${{ needs.get-matrix.outputs.matrix }}
+
+  functional: #-----------------------------------------------------------------
     name: Functional - WP ${{ matrix.wp }} on PHP ${{ matrix.php }} with ${{ matrix.dbtype != 'sqlite' && format('MySQL {0}', matrix.mysql) || 'SQLite' }}
+    needs: prepare-functional
     strategy:
       fail-fast: false
-      matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
-        wp: ['latest']
-        mysql: ['8.0']
-        dbtype: ['mysql', 'sqlite']
-        include:
-          - php: '7.0'
-            wp: 'trunk'
-            mysql: '8.0'
-          - php: '7.0'
-            wp: 'trunk'
-            mysql: '5.7'
-          - php: '7.0'
-            wp: 'trunk'
-            mysql: '5.6'
-          - php: '7.4'
-            wp: 'trunk'
-            mysql: '8.0'
-          - php: '8.0'
-            wp: 'trunk'
-            mysql: '8.0'
-          - php: '8.0'
-            wp: 'trunk'
-            mysql: '5.7'
-          - php: '8.0'
-            wp: 'trunk'
-            mysql: '5.6'
-          - php: '8.1'
-            wp: 'trunk'
-            mysql: '8.0'
-          - php: '8.2'
-            wp: 'trunk'
-            mysql: '8.0'
-          - php: '5.6'
-            wp: '3.7'
-            mysql: '5.6'
-          - php: '5.6'
-            wp: '6.2'
-            mysql: '8.0'
-          - php: '8.3'
-            wp: 'trunk'
-            mysql: '8.0'
-          - php: '8.2'
-            wp: 'trunk'
-            dbtype: 'sqlite'
+      matrix: ${{ fromJson(needs.prepare-functional.outputs.matrix) }}
     runs-on: ubuntu-20.04
 
     continue-on-error: ${{ matrix.php == '8.3' || matrix.dbtype == 'sqlite' }}
@@ -140,24 +288,22 @@ jobs:
 
     steps:
       - name: Check out source code
-        if: ${{ matrix.php >= inputs.minimum-php }}
         uses: actions/checkout@v4
 
       - name: Check existence of composer.json & behat.yml files
-        if: ${{ matrix.php >= inputs.minimum-php }}
         id: check_files
         uses: andstor/file-existence-action@v2
         with:
           files: "composer.json, behat.yml"
 
       - name: Install Ghostscript
-        if: ${{ matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         run: |
           sudo apt-get update
           sudo apt-get install ghostscript -y
 
       - name: Set up PHP environment
-        if: ${{ matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
@@ -168,12 +314,12 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Change ImageMagick policy to allow pdf->png conversion.
-        if: ${{ matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         run: |
           sudo sed -i 's/^.*policy.*coder.*none.*PDF.*//' /etc/ImageMagick-6/policy.xml
 
       - name: Install Composer dependencies & cache dependencies
-        if: ${{ matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         uses: "ramsey/composer-install@v2"
         env:
           COMPOSER_ROOT_VERSION: dev-${{ github.event.repository.default_branch }}
@@ -182,11 +328,11 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Start MySQL server
-        if: ${{ matrix.dbtype != 'sqlite' && matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ matrix.dbtype != 'sqlite' && steps.check_files.outputs.files_exists == 'true' }}
         run: sudo systemctl start mysql
 
       - name: Configure DB environment
-        if: ${{ matrix.dbtype != 'sqlite' && matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ matrix.dbtype != 'sqlite' && steps.check_files.outputs.files_exists == 'true' }}
         run: |
           echo "MYSQL_HOST=127.0.0.1" >> $GITHUB_ENV
           echo "MYSQL_TCP_PORT=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
@@ -198,18 +344,18 @@ jobs:
           echo "WP_CLI_TEST_DBHOST=127.0.0.1:${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
 
       - name: Prepare test database
-        if: ${{ matrix.dbtype != 'sqlite' && matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ matrix.dbtype != 'sqlite' && steps.check_files.outputs.files_exists == 'true' }}
         run: composer prepare-tests
 
       - name: Check Behat environment
-        if: ${{ matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         env:
           WP_VERSION: '${{ matrix.wp }}'
           WP_CLI_TEST_DBTYPE: ${{ matrix.dbtype || 'mysql' }}
         run: WP_CLI_TEST_DEBUG_BEHAT_ENV=1 composer behat
 
       - name: Run Behat
-        if: ${{ matrix.php >= inputs.minimum-php && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         env:
           WP_VERSION: '${{ matrix.wp }}'
           WP_CLI_TEST_DBTYPE: ${{ matrix.dbtype || 'mysql' }}

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -24,7 +24,6 @@ jobs:
             ^.editorconfig
             ^.github/workflows/code-quality.yml
             ^.github/workflows/regenerate-readme.yml
-            ^.github/workflows/testing.yml
           TARGET_REPOS: |
             wp-cli/admin-command
             wp-cli/cache-command

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   test:
-    uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
+    uses: wp-cli/.github/.github/workflows/reusable-testing.yml@separate-matrix-v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   test:
-    uses: wp-cli/.github/.github/workflows/reusable-testing.yml@separate-matrix-v2
+    uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main


### PR DESCRIPTION
Brings the matrix inline into the workflow instead of fetching it remotely from the repository.

Downside: No syntax highlighting
Upside: No need for a curl call; matrix is closer to the workflow, making it easier to grasp

Successfully tested by running this both correctly against this branch as well [over at this repo](https://github.com/wp-cli/checksum-command/pull/118)

---

This is the second attempt at #78

The original description is below:

How it works:

Two new jobs are added to prepare the test matrix for the actual test jobs.

The full matrix is now in a JSON string. Is then processed by `jq` to filter out entries where the PHP version is below `minimum-php`. The test jobs then use this filtered matrix with `fromJson`

This way we avoid unused containers from being created.

Also excludes `testing.yml` from syncing.

Example:

The final matrix for the unit tests will look something like this for `minimum-php = 7.0`:

```json
{"include":[{"php":"7.0"},{"php":"7.0"},{"php":"7.1"},{"php":"7.1"},{"php":"7.2"},{"php":"7.2"},{"php":"7.3"},{"php":"7.3"},{"php":"7.4"},{"php":"7.4"},{"php":"8.0"},{"php":"8.0"},{"php":"8.1"},{"php":"8.1"},{"php":"8.2"},{"php":"8.2"},{"php":"7.0"},{"php":"7.0"},{"php":"7.0"},{"php":"7.4"},{"php":"8.0"},{"php":"8.0"},{"php":"8.0"},{"php":"8.1"},{"php":"8.2"},{"php":"8.3"},{"php":"8.2"}]}
```

For the functional tests there are of course a few more keys:

```json
{"include":[{"php":"7.0","wp":"latest","mysql":"8.0"},{"php":"7.0","wp":"latest","dbtype":"sqlite"},{"php":"7.1","wp":"latest","mysql":"8.0"},{"php":"7.1","wp":"latest","dbtype":"sqlite"},{"php":"7.2","wp":"latest","mysql":"8.0"},{"php":"7.2","wp":"latest","dbtype":"sqlite"},{"php":"7.3","wp":"latest","mysql":"8.0"},{"php":"7.3","wp":"latest","dbtype":"sqlite"},{"php":"7.4","wp":"latest","mysql":"8.0"},{"php":"7.4","wp":"latest","dbtype":"sqlite"},{"php":"8.0","wp":"latest","mysql":"8.0"},{"php":"8.0","wp":"latest","dbtype":"sqlite"},{"php":"8.1","wp":"latest","mysql":"8.0"},{"php":"8.1","wp":"latest","dbtype":"sqlite"},{"php":"8.2","wp":"latest","mysql":"8.0"},{"php":"8.2","wp":"latest","dbtype":"sqlite"},{"php":"7.0","wp":"trunk","mysql":"8.0"},{"php":"7.0","wp":"trunk","mysql":"5.7"},{"php":"7.0","wp":"trunk","mysql":"5.6"},{"php":"7.4","wp":"trunk","mysql":"8.0"},{"php":"8.0","wp":"trunk","mysql":"8.0"},{"php":"8.0","wp":"trunk","mysql":"5.7"},{"php":"8.0","wp":"trunk","mysql":"5.6"},{"php":"8.1","wp":"trunk","mysql":"8.0"},{"php":"8.2","wp":"trunk","mysql":"8.0"},{"php":"8.3","wp":"trunk","mysql":"8.0"},{"php":"8.2","wp":"trunk","dbtype":"sqlite"},{"php":"8.3","wp":"trunk","dbtype":"sqlite"}]}
```

Note I'm not super familiar with `jq`, so these commands can probably be improved.

Aside: I also snuck a PHP 8.3 + WP trunk + SQLite test in there, which we previously didn't have.