### PR TITLE
Do not run matrix if required files do not exist

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -34,8 +34,6 @@ jobs:
       with:
         files: "composer.json, behat.yml"
 
-        # ${{ matrix.php < '7.2' && steps.check_files.outputs.files_exists == 'true' }}
-
     - name: Set matrix
       id: base-matrix
       run: |

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -22,18 +22,6 @@ jobs:
     outputs:
       matrix: ${{ steps.base-matrix.outputs.matrix }}
     steps:
-    - name: Check existence of unit test files
-      id: check_phpunit
-      uses: andstor/file-existence-action@v2
-      with:
-        files: "composer.json, phpunit.xml.dist"
-
-    - name: Check existence of functional test files
-      id: check_behat
-      uses: andstor/file-existence-action@v2
-      with:
-        files: "composer.json, behat.yml"
-
     - name: Set matrix
       id: base-matrix
       run: |

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -22,6 +22,20 @@ jobs:
     outputs:
       matrix: ${{ steps.base-matrix.outputs.matrix }}
     steps:
+    - name: Check existence of unit test files
+      id: check_phpunit
+      uses: andstor/file-existence-action@v2
+      with:
+        files: "composer.json, phpunit.xml.dist"
+
+    - name: Check existence of functional test files
+      id: check_behat
+      uses: andstor/file-existence-action@v2
+      with:
+        files: "composer.json, behat.yml"
+
+        # ${{ matrix.php < '7.2' && steps.check_files.outputs.files_exists == 'true' }}
+
     - name: Set matrix
       id: base-matrix
       run: |
@@ -191,11 +205,23 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Set matrix
-        id: set-matrix
-        run: echo "matrix=$(jq -c '.include |= map(with_entries(select(.key == "php"))) | .include |= map(select(.php >= "${{ inputs.minimum-php }}"))' <<< $BASE_MATRIX)" >> $GITHUB_OUTPUT
-        env:
-          BASE_MATRIX: ${{ needs.get-matrix.outputs.matrix }}
+    - name: Check existence of composer.json file
+      id: check_files
+      uses: andstor/file-existence-action@v2
+      with:
+        files: "composer.json, phpunit.xml.dist"
+
+    - name: Set matrix
+      id: set-matrix
+      run: |
+        if [[ $FILE_EXISTS == 'true' ]]; then
+          echo "matrix=$(jq -c '.include |= map(with_entries(select(.key == "php"))) | .include |= map(select(.php >= "${{ inputs.minimum-php }}"))' <<< $BASE_MATRIX)" >> $GITHUB_OUTPUT
+        else
+          echo "matrix={}" >> $GITHUB_OUTPUT
+        fi
+      env:
+        BASE_MATRIX: ${{ needs.get-matrix.outputs.matrix }}
+        FILE_EXISTS: ${{ steps.check_files.outputs.files_exists == 'true' }}
 
   unit: #-----------------------------------------------------------------------
     name: Unit test /  PHP ${{ matrix.php }}
@@ -211,14 +237,8 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v4
 
-      - name: Check existence of composer.json file
-        id: check_files
-        uses: andstor/file-existence-action@v2
-        with:
-          files: "composer.json, phpunit.xml.dist"
-
       - name: Set up PHP environment (PHP 5.6 - 7.1)
-        if: ${{ matrix.php < '7.2' && steps.check_files.outputs.files_exists == 'true'}}
+        if: ${{ matrix.php < '7.2' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
@@ -229,7 +249,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up PHP environment (PHP 7.2+)
-        if: ${{ matrix.php >= '7.2' && steps.check_files.outputs.files_exists == 'true'}}
+        if: ${{ matrix.php >= '7.2' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
@@ -239,7 +259,6 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies & cache dependencies
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         uses: "ramsey/composer-install@v2"
         env:
           COMPOSER_ROOT_VERSION: dev-${{ github.event.repository.default_branch }}
@@ -248,11 +267,9 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Setup problem matcher to provide annotations for PHPUnit
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Run PHPUnit
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         run: composer phpunit
 
   prepare-functional: #---------------------------------------------------------
@@ -262,11 +279,23 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Check existence of composer.json & behat.yml files
+        id: check_files
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "composer.json, behat.yml"
+
       - name: Set matrix
         id: set-matrix
-        run: echo "matrix=$(jq -c '.include |= map(select(.php >= "${{ inputs.minimum-php }}"))' <<< $BASE_MATRIX)" >> $GITHUB_OUTPUT
+        run: |
+          if [[ $FILE_EXISTS == 'true' ]]; then
+            echo "matrix=$(jq -c '.include |= map(select(.php >= "${{ inputs.minimum-php }}"))' <<< $BASE_MATRIX)" >> $GITHUB_OUTPUT
+          else
+            echo "matrix={}" >> $GITHUB_OUTPUT
+          fi
         env:
           BASE_MATRIX: ${{ needs.get-matrix.outputs.matrix }}
+          FILE_EXISTS: ${{ steps.check_files.outputs.files_exists == 'true' }}
 
   functional: #-----------------------------------------------------------------
     name: Functional - WP ${{ matrix.wp }} on PHP ${{ matrix.php }} with ${{ matrix.dbtype != 'sqlite' && format('MySQL {0}', matrix.mysql) || 'SQLite' }}
@@ -290,20 +319,12 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v4
 
-      - name: Check existence of composer.json & behat.yml files
-        id: check_files
-        uses: andstor/file-existence-action@v2
-        with:
-          files: "composer.json, behat.yml"
-
       - name: Install Ghostscript
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         run: |
           sudo apt-get update
           sudo apt-get install ghostscript -y
 
       - name: Set up PHP environment
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
@@ -314,12 +335,10 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Change ImageMagick policy to allow pdf->png conversion.
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         run: |
           sudo sed -i 's/^.*policy.*coder.*none.*PDF.*//' /etc/ImageMagick-6/policy.xml
 
       - name: Install Composer dependencies & cache dependencies
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         uses: "ramsey/composer-install@v2"
         env:
           COMPOSER_ROOT_VERSION: dev-${{ github.event.repository.default_branch }}
@@ -328,11 +347,11 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Start MySQL server
-        if: ${{ matrix.dbtype != 'sqlite' && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ matrix.dbtype != 'sqlite' }}
         run: sudo systemctl start mysql
 
       - name: Configure DB environment
-        if: ${{ matrix.dbtype != 'sqlite' && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ matrix.dbtype != 'sqlite' }}
         run: |
           echo "MYSQL_HOST=127.0.0.1" >> $GITHUB_ENV
           echo "MYSQL_TCP_PORT=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
@@ -344,18 +363,16 @@ jobs:
           echo "WP_CLI_TEST_DBHOST=127.0.0.1:${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
 
       - name: Prepare test database
-        if: ${{ matrix.dbtype != 'sqlite' && steps.check_files.outputs.files_exists == 'true' }}
+        if: ${{ matrix.dbtype != 'sqlite' }}
         run: composer prepare-tests
 
       - name: Check Behat environment
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         env:
           WP_VERSION: '${{ matrix.wp }}'
           WP_CLI_TEST_DBTYPE: ${{ matrix.dbtype || 'mysql' }}
         run: WP_CLI_TEST_DEBUG_BEHAT_ENV=1 composer behat
 
       - name: Run Behat
-        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
         env:
           WP_VERSION: '${{ matrix.wp }}'
           WP_CLI_TEST_DBTYPE: ${{ matrix.dbtype || 'mysql' }}

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -191,23 +191,26 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - name: Check existence of composer.json file
-      id: check_files
-      uses: andstor/file-existence-action@v2
-      with:
-        files: "composer.json, phpunit.xml.dist"
+      - name: Check out source code
+        uses: actions/checkout@v4
 
-    - name: Set matrix
-      id: set-matrix
-      run: |
-        if [[ $FILE_EXISTS == 'true' ]]; then
-          echo "matrix=$(jq -c '.include |= map(with_entries(select(.key == "php"))) | .include |= map(select(.php >= "${{ inputs.minimum-php }}"))' <<< $BASE_MATRIX)" >> $GITHUB_OUTPUT
-        else
-          echo "matrix={}" >> $GITHUB_OUTPUT
-        fi
-      env:
-        BASE_MATRIX: ${{ needs.get-matrix.outputs.matrix }}
-        FILE_EXISTS: ${{ steps.check_files.outputs.files_exists == 'true' }}
+      - name: Check existence of composer.json file
+        id: check_files
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "composer.json, phpunit.xml.dist"
+
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          if [[ $FILE_EXISTS == 'true' ]]; then
+            echo "matrix=$(jq -c '.include |= map(with_entries(select(.key == "php"))) | .include |= map(select(.php >= "${{ inputs.minimum-php }}"))' <<< $BASE_MATRIX)" >> $GITHUB_OUTPUT
+          else
+            echo "matrix={}" >> $GITHUB_OUTPUT
+          fi
+        env:
+          BASE_MATRIX: ${{ needs.get-matrix.outputs.matrix }}
+          FILE_EXISTS: ${{ steps.check_files.outputs.files_exists == 'true' }}
 
   unit: #-----------------------------------------------------------------------
     name: Unit test /  PHP ${{ matrix.php }}
@@ -265,6 +268,9 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+
       - name: Check existence of composer.json & behat.yml files
         id: check_files
         uses: andstor/file-existence-action@v2

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v4
 
-      - name: Check existence of composer.json file
+      - name: Check existence of composer.json & phpunit.xml.dist files
         id: check_files
         uses: andstor/file-existence-action@v2
         with:


### PR DESCRIPTION
Right now we generate a complex build matrix for unit & function tests, and within each job check if we actually need to run the tests or not.

Thanks to the new separate job for building the matrix we can simple build an empty matrix if the relevant files do not exist.

For example, in this repo no test jobs should be started because there are no tests. [Or in the checksum command repo](https://github.com/wp-cli/checksum-command/pull/118), no unit tests should be run because there are non.