### PR TITLE
Test WordPress trunk on PHP 7.2+

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -109,17 +109,17 @@ jobs:
               "dbtype": "sqlite"
             },
             {
-              "php": "7.0",
+              "php": "7.2",
               "wp": "trunk",
               "mysql": "8.0"
             },
             {
-              "php": "7.0",
+              "php": "7.2",
               "wp": "trunk",
               "mysql": "5.7"
             },
             {
-              "php": "7.0",
+              "php": "7.2",
               "wp": "trunk",
               "mysql": "5.6"
             },

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -177,6 +177,16 @@ jobs:
               "php": "8.3",
               "wp": "trunk",
               "dbtype": "sqlite"
+            },
+            {
+              "php": "8.4",
+              "wp": "trunk",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.4",
+              "wp": "trunk",
+              "dbtype": "sqlite"
             }
           ]
         }
@@ -220,6 +230,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare-unit.outputs.matrix) }}
     runs-on: ubuntu-20.04
+
+    continue-on-error: ${{ matrix.php == '8.4' }}
 
     steps:
       - name: Check out source code


### PR DESCRIPTION
Need to merge this to stop any trunk tests from failing, as WP just increased the minimum required PHP version to 7.2.24, see https://core.trac.wordpress.org/changeset/57985

Also adds experimental tests against PHP 8.4 alpha so that we can spot any issues early.