### PR TITLE
Update matrix to remove WP 6.6 with PHP less than 7.2

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -34,26 +34,6 @@ jobs:
         {
           "include": [
             {
-              "php": "7.0",
-              "wp": "latest",
-              "mysql": "8.0"
-            },
-            {
-              "php": "7.0",
-              "wp": "latest",
-              "dbtype": "sqlite"
-            },
-            {
-              "php": "7.1",
-              "wp": "latest",
-              "mysql": "8.0"
-            },
-            {
-              "php": "7.1",
-              "wp": "latest",
-              "dbtype": "sqlite"
-            },
-            {
               "php": "7.2",
               "wp": "latest",
               "mysql": "8.0"


### PR DESCRIPTION
* Latest version (6.6) requires minimum PHP 7.2