### PR TITLE
GH Actions/reusable-testing: remove redundant step

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -222,19 +222,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v4
 
-      - name: Set up PHP environment (PHP 5.6 - 7.1)
-        if: ${{ matrix.php < '7.2' }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '${{ matrix.php }}'
-          coverage: none
-          tools: composer:2.2,cs2pr
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up PHP environment (PHP 7.2+)
-        if: ${{ matrix.php >= '7.2' }}
+      - name: Set up PHP environment
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'


### PR DESCRIPTION
`setup-php` will automatically install a compliant version of Composer based on the PHP version. No need to have the extra step.