### PR TITLE
GH Actions/tests: set error reporting to display all notices

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -226,6 +226,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: none
           tools: composer,cs2pr
         env:
@@ -297,6 +298,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           extensions: gd, imagick, mysql, zip
           coverage: none
           tools: composer


### PR DESCRIPTION
The default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `-1` (always include all error levels on all PHP versions) and `display_errors=On` to ensure **all** PHP notices are shown.

This is now fixed by adding the `ini-values` setting to `setup-php`.