### PR TITLE
GH Actions/linting: show deprecations when linting

### DIFF
--- a/.github/workflows/reusable-code-quality.yml
+++ b/.github/workflows/reusable-code-quality.yml
@@ -29,6 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 'latest'
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           tools: cs2pr
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +51,7 @@ jobs:
 
       - name: Run Linter
         if: steps.check_linter_file.outputs.files_exists == 'true'
-        run: vendor/bin/parallel-lint -j 10 . --exclude vendor --checkstyle | cs2pr
+        run: vendor/bin/parallel-lint -j 10 . --show-deprecated --exclude vendor --exclude .git --checkstyle | cs2pr
 
   phpcs: #----------------------------------------------------------------------
     name: PHPCS


### PR DESCRIPTION
While rare, there are some deprecations which PHP can show when a file is being linted. By default these are ignored by PHP-Parallel-Lint.

However, there is an option to show them, so let's turn that option on.

To make the option effective, we also need to ensure that PHP is run in a way that all errors will be shown, which is not the case by default, so this also sets some `ini-values` for PHP to a more optimal setting for CI.

Lastly, in the command, let's also make the package directory iteration a little faster by preventing parallel lint from having to iterate through the `.git` directory when there are no PHP files to be found there anyway.