### PR TITLE
GH Actions/testing: minor simplification/maintainability improvement

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -164,12 +164,12 @@ jobs:
               "dbtype": "sqlite"
             },
             {
-              "php": "8.4",
+              "php": "nightly",
               "wp": "trunk",
               "mysql": "8.0"
             },
             {
-              "php": "8.4",
+              "php": "nightly",
               "wp": "trunk",
               "dbtype": "sqlite"
             }
@@ -216,7 +216,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-unit.outputs.matrix) }}
     runs-on: ubuntu-20.04
 
-    continue-on-error: ${{ matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.php == 'nightly' }}
 
     steps:
       - name: Check out source code
@@ -282,7 +282,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-functional.outputs.matrix) }}
     runs-on: ubuntu-20.04
 
-    continue-on-error: ${{ matrix.dbtype == 'sqlite' || matrix.php == '8.4' }}
+    continue-on-error: ${{ matrix.dbtype == 'sqlite' || matrix.php == 'nightly' }}
 
     steps:
       - name: Check out source code


### PR DESCRIPTION
Setup-PHP has an alias available for "PHP next" named `nightly`.

While this change doesn't remove the annual task of updating the matrix when a new PHP version gets released, it does make this update a little less error prone as updating the `continue-on-error` conditions lower down in the scripts (disconnected from the matrix set up) can easily be forgotten.

There are a few caveats to keep in mind about this change though:
* Manually updating the matrix and the workflow gives (of course) more control over the exact PHP versions being used.
* When using `nightly`, that control is relinquished partially to setup-php and partially to PHP itself as `nightly` will generally always be "PHP next".
    This means that `nightly` will effectively become PHP `8.5` at the time when setup-php updates the alias, which can be at any point in time between PHP src branching off the PHP `8.4` branch (happened last week when the first RC was created) and the moment PHP `8.4` is released.
    Note: there is [some discussion going](https://github.com/shivammathur/setup-php/issues/867) to clarify when "nightly" becomes "PHP next next" (`8.5`). Looks like the current intention is to not change it until PHP 8.4 has been released.

You can always check exactly what version is used for `nightly` though, by folding out the "Set up PHP environment" step and checking the PHP version listed there.

![image](https://github.com/user-attachments/assets/5a1f5b25-9971-4c8c-a21b-6368cc33db6c)

(example from a repo using `nightly` on a run from today)

Ref:
* https://github.com/shivammathur/setup-php/?tab=readme-ov-file#php-version-optional