### PR TITLE
GH Actions/tests: prevent warning about outdated configuration being used

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -239,6 +239,26 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
+      - name: Grab PHPUnit version
+        id: phpunit_version
+        run: echo "VERSION=$(vendor/bin/phpunit --version | grep --only-matching --max-count=1 --extended-regexp '\b[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
+
+      - name: Determine PHPUnit flavour
+        id: phpunit_version
+        run: |
+          if [ startsWith( steps.phpunit_version.outputs.VERSION, '10.' ) }}" == "true" ]; then
+            echo 'FLAVOUR=gte10' >> $GITHUB_OUTPUT
+          else
+            echo 'FLAVOUR=lte9' >> $GITHUB_OUTPUT
+          fi
+
+      # PHPUnit 10 may fail a test run when the "old" configuration format is used.
+      # Luckily, there is a build-in migration tool since PHPUnit 9.3.
+      - name: Migrate PHPUnit configuration for PHPUnit 10+
+        if: ${{ steps.phpunit_version.outputs.FLAVOUR == 'gte10' }}
+        continue-on-error: true
+        run: composer phpunit -- --migrate-configuration
+
       - name: Setup problem matcher to provide annotations for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 


### PR DESCRIPTION
The configuration file specification has undergone changes in PHPUnit 9.3 and 10.0.

Most notably:
* In PHPUnit 9.3, the manner of specifying the code coverage configuration has changed.
* In PHPUnit 10.0, a significant number of attributes of the `<phpunit>` element were removed or renamed.

When running PHPUnit 10 with  a PHPUnit 9 style configuration file, PHPUnit 10 can show a warning:
```
There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!
```

The `--migrate-configuration` command can upgrade a configuration for the changes in the format made in PHPUnit 9.3 and 10.0/10.1, but some of the changes in the configuration format in PHPUnit 10 don't have one-on-one replacements and/or are not taken into account.

This commit is a way to "future proof" the test workflow a little by preventing that PHPUnit warning from potentially failing a build in the future.

Notes:
* If/when PHPUnit 11 starts to be supported, the bash condition will need updating to also recognize PHPUnit 11.
* The `--migrate-configuration` script will fail (exit code `1`) if no update is needed, like if one of the repos would have a PHPUnit 10-style config file.
    To prevent this from failing the test job, I'm explicitly setting `continue-on-error: true`.