### PR TITLE
Let Dependabot update GitHub Actions dependencies

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - scope:distribution
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - scope:distribution


### PR DESCRIPTION
Currently, Dependabot only looks for Composer dependency updates. However, there are also GitHub Actions workflows included in this repository, which make use of third-party actions.

This PR updates the Dependabot config file to also cover GHA dependencies. This is actually in line with how some WP-CLI package repositories have the `dependabot.yml` file set up, so I thought it made sense to add it to this repository too.