### PR TITLE
Disable error reporting for Behat tests on 8.4

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -309,7 +309,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
-          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          ini-values: ${{ matrix.php != 'nightly' && 'zend.assertions=1, error_reporting=-1, display_errors=On' }}
           extensions: gd, imagick, mysql, zip
           coverage: none
           tools: composer


### PR DESCRIPTION
This is a follow-up to #105 which set error reporting to display all notices.

While this change already helped catch some bugs, it also currently prevents us from running Behat tests on PHP 8.4 due to the deprecations thrown in Behat.

This is meant to be a temporary change until a new Behat version without the deprecations is available, allowing us to at least run the tests again.