### PR TITLE
Revert "Disable error reporting for Behat tests on 8.4"

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -309,7 +309,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
-          ini-values: ${{ matrix.php != 'nightly' && 'zend.assertions=1, error_reporting=-1, display_errors=On' || '' }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           extensions: gd, imagick, mysql, zip
           coverage: none
           tools: composer


### PR DESCRIPTION
This reverts commit 2c169bf7862a55c2fc021a7fe9c8b12291edefc4 and addc0927be6e45fe29273ab66ef40e38f2532968.

[Behat v3.15.0](https://github.com/Behat/Behat/releases/tag/v3.15.0) was just released with improved PHP 8.4 support, so there shouldn't be any more deprecation warnings when running Behat tests on PHP 8.4