### PR TITLE
GH Actions: PHP 8.4 has been released

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -164,6 +164,16 @@ jobs:
               "dbtype": "sqlite"
             },
             {
+              "php": "8.4",
+              "wp": "trunk",
+              "mysql": "8.0"
+            },
+            {
+              "php": "8.4",
+              "wp": "trunk",
+              "dbtype": "sqlite"
+            },
+            {
               "php": "nightly",
               "wp": "trunk",
               "mysql": "8.0"


### PR DESCRIPTION
PHP 8.4 needs to be explicitly required now. PHP "nightly" is now PHP 8.5.

Ref: https://www.php.net/releases/8.4/en.php