### PR TITLE
Fix Behat error reporting once again

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -319,7 +319,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '${{ matrix.php }}'
-          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          # Disable error reporting for Behat tests on PHP 8.4+, as long as Behat is not upgraded to a newer version.
+          ini-values: ${{ matrix.php != '8.4' && matrix.php != 'nightly' && 'zend.assertions=1, error_reporting=-1, display_errors=On' || '' }}
           extensions: gd, imagick, mysql, zip
           coverage: none
           tools: composer


### PR DESCRIPTION
This reverts #114 again for PHP 8.4 and nightly, because we can't actually use Behat v3.15.0 just yet without bumping our minimum PHP version requirement. See https://github.com/wp-cli/wp-cli-tests/pull/228