### PR TITLE
Use pretty Behat output if debug logging is on

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -405,7 +405,12 @@ jobs:
           WP_CLI_TEST_DBTYPE: ${{ matrix.dbtype || 'mysql' }}
           WP_CLI_TEST_DBSOCKET: '${{ steps.setup-mysql.outputs.base-dir }}/tmp/mysql.sock'
           WP_CLI_TEST_COVERAGE: ${{ matrix.coverage }}
-        run: composer behat || composer behat-rerun
+        run: |
+          if [[ $RUNNER_DEBUG == '1' ]]; then
+            composer behat -- --format=pretty || composer behat-rerun -- --format=pretty
+          else
+            composer behat || composer behat-rerun
+          fi
 
       - name: Retrieve list of coverage files
         id: coverage_files


### PR DESCRIPTION
`RUNNER_DEBUG` is set only if [debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) is enabled, and always has the value of 1. It can be useful as an indicator to enable additional debugging or verbose logging in your own job steps.