### PR TITLE
Add spellcheck GitHub Action

### DIFF
--- a/.github/workflows/reusable-code-quality.yml
+++ b/.github/workflows/reusable-code-quality.yml
@@ -111,6 +111,23 @@ jobs:
       - name: Run linter
         run: npx --yes gherkin-lint -c $RUNNER_TEMP/.gherkin-lintrc
 
+  lint-spellcheck: #----------------------------------------------------------------
+    name: Spell check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+
+      - name: Check existence of config file
+        id: check_files
+        uses: andstor/file-existence-action@v3
+        with:
+          files: ".typos.toml"
+
+      - name: Check spelling
+        if: steps.check_files.outputs.files_exists == 'true'
+        uses: crate-ci/typos@v1.32.0
+
   phpcs: #----------------------------------------------------------------------
     name: PHPCS
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli-tests/issues/122

This job will only run when a config file is found in the project.

It doesn't match the requirements of having a central config in the wp-cli-tests config, but the https://github.com/crate-ci/typos tool needs custom per-project configuration anyway to ignore false positives etc.

We could do something similar as with the Gherkin lint though by downloading the config file from wp-cli-tests in the job first. But then we'd need to figure out how that one could be overridden.