### PR TITLE
Remove xdebug arg logic

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -473,7 +473,7 @@ jobs:
           WP_CLI_TEST_DBTYPE: ${{ matrix.dbtype || 'mysql' }}
           WP_CLI_TEST_DBSOCKET: '${{ steps.setup-mysql.outputs.base-dir }}/tmp/mysql.sock'
           WP_CLI_TEST_COVERAGE: ${{ matrix.coverage }}
-          BEHAT_ARGS: ${{ format( '{0} {1}', matrix.coverage && '--xdebug', runner.debug && '--format-pretty' ) }}
+          BEHAT_ARGS: ${{ format( '{0}', runner.debug && '--format-pretty' ) }}
         run: |
           composer behat -- $BEHAT_ARGS || composer behat-rerun -- $BEHAT_ARGS
 


### PR DESCRIPTION
Should be handled directly by wp-cli-tests, see https://github.com/wp-cli/wp-cli-tests/pull/276