### PR TITLE
Update test matrix after WordPress 7.0 release

### DIFF
--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -55,22 +55,22 @@ jobs:
             },
             {
               "php": "7.2",
-              "wp": "latest",
+              "wp": "6.9",
               "mysql": "mysql-8.0"
             },
             {
               "php": "7.2",
-              "wp": "latest",
+              "wp": "6.9",
               "dbtype": "sqlite"
             },
             {
               "php": "7.3",
-              "wp": "latest",
+              "wp": "6.9",
               "mysql": "mysql-8.0"
             },
             {
               "php": "7.3",
-              "wp": "latest",
+              "wp": "6.9",
               "dbtype": "sqlite"
             },
             {


### PR DESCRIPTION
WordPress 7.0 requires PHP 7.4+

Thus, we now run PHP 7.2 and 7.3 tests against WP 6.9, the last release to officially support these versions.