### PR TITLE
Avoid MariaDB SSL client warning in tests

### DIFF
--- a/.github/workflows/reusable-functional.yml
+++ b/.github/workflows/reusable-functional.yml
@@ -115,7 +115,7 @@ jobs:
           my-cnf: |
             ${{ steps.mysql-config.outputs.auth-config || 'default_authentication_plugin=mysql_native_password' }}
             ${{ inputs.dbtype == 'mariadb' && '[client]' || '' }}
-            ${{ inputs.dbtype == 'mariadb' && 'disable-ssl-verify-server-cert' || '' }}
+            ${{ inputs.dbtype == 'mariadb' && 'skip-ssl' || '' }}
 
       - name: Remove system MySQL binary
         if: ${{ inputs.dbtype != 'sqlite' }}


### PR DESCRIPTION
## Summary
- Replace MariaDB's `disable-ssl-verify-server-cert` client option with `skip-ssl` in the shared functional workflow.
- Avoid repeated MariaDB 11.4 client warnings on STDERR that cause strict Behat runs to fail even when commands exit successfully.

## Testing
- `git diff --check`
- Confirmed failed `wp-cli/db-command` MariaDB 11.4 Behat jobs were emitting `WARNING: option --ssl-verify-server-cert is disabled, because of an insecure passwordless login.`
