### PR TITLE
Disable Windows Defender real-time scanning during Behat runs

### DIFF
--- a/.github/workflows/reusable-functional.yml
+++ b/.github/workflows/reusable-functional.yml
@@ -51,6 +51,16 @@ jobs:
       WP_CLI_TEST_OBJECT_CACHE: ${{ inputs.object_cache }}
 
     steps:
+      # The Behat suite spawns a large number of short-lived `wp`/`php`
+      # processes and writes many files per scenario. On the Windows runner,
+      # Defender's real-time scanning inspects each of these, which slows the
+      # run down by several times compared to Linux. Turning it off for the
+      # duration of this ephemeral job cuts the wall-clock time dramatically.
+      - name: Disable Windows Defender real-time scanning
+        if: ${{ startsWith(inputs.os, 'windows') }}
+        shell: pwsh
+        run: Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
+
       - name: Check out source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## What

Adds a single guarded step to the reusable functional-testing workflow that turns off Windows Defender real-time monitoring on the Windows runner before the rest of the job runs.

```yaml
- name: Disable Windows Defender real-time scanning
  if: ${{ startsWith(inputs.os, 'windows') }}
  shell: pwsh
  run: Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
```

## Why

The Behat suite spawns a large number of short-lived `wp`/`php` processes and writes many files per scenario. On the Windows runner, Defender's real-time scanning inspects every spawned process and every file write, which makes the functional job run several times slower than the equivalent Linux job.

Measured on a recent `extension-command` PR run (PHP 8.5 / WP trunk / SQLite, same 262 scenarios):

| Runner | Behat run | Total job |
|--------|-----------|-----------|
| Linux  | ~27 min   | ~29 min   |
| Windows | ~84 min  | ~86 min   |

Setup (checkout, Chocolatey, `setup-php`, Composer) accounts for only ~2 minutes; effectively all of the Windows overhead is the single-threaded Behat run, and the progression is uniform across scenarios rather than caused by one slow test. That points at per-process/per-file overhead, which is exactly what Defender's real-time scanning adds.

## Notes

- The runner is ephemeral and thrown away after the job, so disabling real-time monitoring for its lifetime has no lasting effect.
- The step is guarded to Windows and uses `-ErrorAction SilentlyContinue`, so it is a harmless no-op on Linux/macOS and won't fail the job if the cmdlet is ever restricted.
- Placed as the first step so checkout, `setup-php`, and Composer benefit as well, not just Behat.
- The Windows functional job is already `continue-on-error`, so this only changes how long the informational job takes, not whether it can block a PR.

## Verification

The `.github` repo doesn't run functional tests against itself. To confirm the speedup, point a package's `testing.yml` (or the `reusable-workflow-test` repo) at this branch and compare the Windows job duration against a `main` run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows-based functional test runs to reduce delays caused by real-time antivirus scanning.
  * The adjustment applies only during the relevant test job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->