### PR TITLE
Revert Windows Defender step (no-op on GitHub runners)

### DIFF
--- a/.github/workflows/reusable-functional.yml
+++ b/.github/workflows/reusable-functional.yml
@@ -51,16 +51,6 @@ jobs:
       WP_CLI_TEST_OBJECT_CACHE: ${{ inputs.object_cache }}
 
     steps:
-      # The Behat suite spawns a large number of short-lived `wp`/`php`
-      # processes and writes many files per scenario. On the Windows runner,
-      # Defender's real-time scanning inspects each of these, which slows the
-      # run down by several times compared to Linux. Turning it off for the
-      # duration of this ephemeral job cuts the wall-clock time dramatically.
-      - name: Disable Windows Defender real-time scanning
-        if: ${{ startsWith(inputs.os, 'windows') }}
-        shell: pwsh
-        run: Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
-
       - name: Check out source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
Reverts the Defender step added in #267.

## Why

#267 disabled Windows Defender real-time scanning on the Windows functional job, on the theory that Defender's per-process scanning was making the Windows runner several times slower than Linux. Measuring it showed **no effect**: ~79 min vs ~84 min for the same suite, within Windows runner variance.

A `Get-MpComputerStatus` probe on the runner explains why:

```
RealTimeProtectionEnabled : False
IsTamperProtected         : False
AntivirusEnabled          : True
```

GitHub's `windows-latest` image already ships with real-time protection **off**, so `Set-MpPreference -DisableRealtimeMonitoring` (and an `Add-MpPreference -ExclusionPath` fallback) have nothing to turn off. The step is a no-op and misleads future maintainers into thinking Windows Defender is handled.

## What's actually slow

Effectively all of the Windows job time is the single `Run Behat` step (~80 min; setup is ~2 min), and it's uniform per-scenario overhead rather than one slow test. That's inherent to running the process-heavy Behat suite on Windows: short-lived `wp`/`php` process spawning, PHP cold-start, and NTFS file I/O per scenario. No Defender setting addresses it.

The job is already `continue-on-error` (informational, never blocks a PR). The lever that would actually cut wall-clock is running *less* on Windows (a tagged smoke subset) or sharding it, which can be pursued separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows functional testing workflows to no longer disable Microsoft Defender real-time scanning during test runs.
  * All other testing steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->