### PR TITLE
Speed up Windows functional tests by using the D: drive

### DIFF
--- a/.github/workflows/reusable-functional.yml
+++ b/.github/workflows/reusable-functional.yml
@@ -51,6 +51,28 @@ jobs:
       WP_CLI_TEST_OBJECT_CACHE: ${{ inputs.object_cache }}
 
     steps:
+      # The Behat suite is heavily I/O- and process-bound: every scenario
+      # installs WordPress and spawns many short-lived `wp` processes. On the
+      # GitHub Windows runner those working files land on the slow C: drive.
+      # Relocating them to the fast D: drive roughly halves the Behat run time.
+      # The wp-cli-tests framework derives the WP install dir, all core/install/
+      # SQLite caches and HOME/COMPOSER_HOME (the WP-CLI cache) from
+      # sys_get_temp_dir(), and forwards TEMP/TMP to the spawned `wp` processes,
+      # so pointing TEMP/TMP at D: relocates all of it. Guarded so it is a no-op
+      # if the D: drive is ever unavailable.
+      - name: Use the fast D drive for temporary files
+        if: ${{ startsWith(inputs.os, 'windows') }}
+        shell: pwsh
+        run: |
+          if (Test-Path 'D:\') {
+            New-Item -ItemType Directory -Force -Path 'D:\Temp' | Out-Null
+            "TEMP=D:\Temp" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            "TMP=D:\Temp"  | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            Write-Host 'Using D:\Temp for temporary files.'
+          } else {
+            Write-Host 'D: drive not available; using the default temp location.'
+          }
+
       - name: Check out source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -317,7 +317,7 @@ jobs:
               "php": "8.5",
               "wp": "trunk",
               "dbtype": "sqlite",
-              "os": "windows-latest"
+              "os": "windows-2022"
             }
           ]
         }


### PR DESCRIPTION
## What

Two changes to the Windows functional (Behat) job:

1. A Windows-only step (before checkout) that redirects `TEMP`/`TMP` to `D:\Temp`, guarded to be a no-op if the `D:` drive is unavailable.
2. Pins the Windows matrix entry to `windows-2022` (the `D:` drive was removed from `windows-2025`).

No changes to Linux/macOS jobs.

## Why

The Windows functional job is by far the slowest in the matrix (well over an hour vs ~30 min on Linux for the same 262 scenarios). Nearly all of it is the Behat run: each scenario installs WordPress and spawns many short-lived `wp`/`php` processes, and on the Windows runner that file I/O all happens on the slow C: drive. GitHub's Windows runners have a read-optimized (slow) C: drive and a fast D: working drive.

Because the `wp-cli-tests` framework derives the WP install directory (`RUN_DIR`), the core/install/SQLite caches, and `HOME`/`COMPOSER_HOME` (the WP-CLI cache) all from `sys_get_temp_dir()`, and forwards `TEMP`/`TMP` to the spawned `wp` processes, a single `TEMP`/`TMP` redirect relocates everything onto D:.

## Measurements

Measured on `extension-command` (PHP 8.5 / WP trunk / SQLite), every run a full 262/262-scenario clean pass:

| Config | Behat run (min) |
|--------|-----------------|
| windows-2022, temp on C: (baseline) | ~74.8 |
| **windows-2022, temp on D: (this PR)** | **23, 25, 43, 43** |
| windows-latest (2025), no D: | ~79–104 |

Redirecting to D: roughly halves the Behat time. Windows runner performance is highly variable (bimodal, ~24 or ~43 min depending on the Azure host), so the result is a band rather than a single number, but the ~2x improvement clears the variance comfortably.

## Alternatives considered and rejected

- **OPcache file cache on D:** no measurable benefit (same-batch A/B: 42.9 min without vs 45.4 min with, i.e. slightly worse). Each scenario installs WordPress at a unique temp path, so `opcache.file_cache` misses across scenarios; only the stable-path framework code is reused, which is negligible, while the bytecode serialization adds a little overhead. Left out to keep the change simple.
- **Dev Drive (ReFS VHDX) on windows-latest:** ~90 min, far slower than the physical D: drive, so it does not recover the win on windows-2025.
- **Windows Defender tweaks:** already ruled out separately (real-time protection is off on these runners); see #268.

## Notes

- The Windows job is `continue-on-error` (informational), so this only changes how long it takes, not whether it can block a PR.
- Pinning to `windows-2022` trades newest-image coverage for the D: drive; the job exists to catch Windows-specific breakage rather than to track the latest Windows image, and windows-2025 is both slower and lacks the D: drive.
- The `.github` repo doesn't run functional tests against itself; the numbers above come from pointing a package's `testing.yml` at this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Windows test execution by using a consistent Windows 2022 environment.
  * Optimized temporary file handling during Windows functional tests by redirecting temp storage to a faster drive when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->