### PR TITLE
Remove `actions: write` from triage workflow

### DIFF
--- a/.github/workflows/reusable-issue-triage.yml
+++ b/.github/workflows/reusable-issue-triage.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Analyze with AI
         id: ai-triage
-        uses: actions/ai-inference@a7805884c80886efc241e94a5351df715968a0ad # v2
+        uses: actions/ai-inference@2c43c91ae16266ca159d311430343c67a5ffa222 # v3
         env:
           AVAILABLE_LABELS: ${{ steps.get-labels.outputs.result }}
           ITEM_TITLE: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.title || github.event.issue.title }}
@@ -265,7 +265,7 @@ jobs:
 
       - name: Analyze with AI
         id: ai-triage
-        uses: actions/ai-inference@a7805884c80886efc241e94a5351df715968a0ad # v2
+        uses: actions/ai-inference@2c43c91ae16266ca159d311430343c67a5ffa222 # v3
         env:
           AVAILABLE_LABELS: ${{ steps.get-labels.outputs.result }}
           ITEM_TITLE: ${{ fromJSON(steps.get-item.outputs.result).title }}

--- a/.github/workflows/reusable-issue-triage.yml
+++ b/.github/workflows/reusable-issue-triage.yml
@@ -12,7 +12,6 @@ name: Issue and PR Triage
 permissions:
   issues: write
   pull-requests: write
-  actions: write
   contents: read
   models: read
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated issue triage to use the latest AI inference action.
  * Reduced workflow permissions to improve security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->