### PR TITLE
Revert "Remove `actions: write` from triage workflow"

### DIFF
--- a/.github/workflows/reusable-issue-triage.yml
+++ b/.github/workflows/reusable-issue-triage.yml
@@ -12,6 +12,7 @@ name: Issue and PR Triage
 permissions:
   issues: write
   pull-requests: write
+  actions: write
   contents: read
   models: read
 
@@ -36,7 +37,7 @@ jobs:
 
       - name: Analyze with AI
         id: ai-triage
-        uses: actions/ai-inference@2c43c91ae16266ca159d311430343c67a5ffa222 # v3
+        uses: actions/ai-inference@a7805884c80886efc241e94a5351df715968a0ad # v2
         env:
           AVAILABLE_LABELS: ${{ steps.get-labels.outputs.result }}
           ITEM_TITLE: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.title || github.event.issue.title }}
@@ -265,7 +266,7 @@ jobs:
 
       - name: Analyze with AI
         id: ai-triage
-        uses: actions/ai-inference@2c43c91ae16266ca159d311430343c67a5ffa222 # v3
+        uses: actions/ai-inference@a7805884c80886efc241e94a5351df715968a0ad # v2
         env:
           AVAILABLE_LABELS: ${{ steps.get-labels.outputs.result }}
           ITEM_TITLE: ${{ fromJSON(steps.get-item.outputs.result).title }}


### PR DESCRIPTION
Reverts wp-cli/.github#271