### PR TITLE
Restore self-describing names on the test jobs

### DIFF
--- a/.github/workflows/reusable-functional.yml
+++ b/.github/workflows/reusable-functional.yml
@@ -35,11 +35,12 @@ permissions:
 
 jobs:
   functional:
-    # The calling job already states "Behat | PHP x" and groups on it, so this only
-    # needs to identify the leg within that group. The database version is spelled
+    # This name has to stand on its own. The run view labels a nested job with its
+    # own name only; the calling job's name is not surfaced at this depth, so
+    # anything omitted here is not shown anywhere. The database version is spelled
     # out because "MySQL" alone rendered the mysql-8.0 and mysql-8.4 legs
     # identically.
-    name: WP ${{ inputs.wp }} | ${{ inputs.dbtype == 'sqlite' && 'SQLite' || inputs.mysql || 'MySQL' }}${{ inputs.object_cache == 'sqlite' && ' (Obj Cache)' || '' }}${{ inputs.coverage && ' (with coverage)' || '' }}${{ startsWith( inputs.os, 'windows' ) && ' (Windows)' || '' }}${{ startsWith( inputs.os, 'macos' ) && ' (macOS)' || '' }}
+    name: Behat | PHP ${{ inputs.php }} | WP ${{ inputs.wp }} | ${{ inputs.dbtype == 'sqlite' && 'SQLite' || inputs.mysql || 'MySQL' }}${{ inputs.object_cache == 'sqlite' && ' (Obj Cache)' || '' }}${{ inputs.coverage && ' (with coverage)' || '' }}${{ startsWith( inputs.os, 'windows' ) && ' (Windows)' || '' }}${{ startsWith( inputs.os, 'macos' ) && ' (macOS)' || '' }}
     # Repositories with a heavy Behat suite can point the default Linux legs at a
     # larger runner by setting the `RUNNERS_NAME` repository variable, without
     # having to fork this workflow. Explicit macOS/Windows legs are unaffected.

--- a/.github/workflows/reusable-testing.yml
+++ b/.github/workflows/reusable-testing.yml
@@ -513,9 +513,10 @@ jobs:
   unit:
     needs: prepare
     if: ${{ needs.prepare.outputs.unit != '' }}
-    # The calling job's name is what the run view groups by, so it carries the
-    # grouping key. The called workflow names the individual leg within the group.
-    name: Unit | PHP ${{ matrix.php }}
+    # Static on purpose. At this nesting depth the run view does not surface this
+    # name, so putting distinguishing detail here would hide it; the called
+    # workflow carries the full leg name instead.
+    name: Unit
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.unit) }}
@@ -529,9 +530,10 @@ jobs:
   functional:
     needs: prepare
     if: ${{ needs.prepare.outputs.functional != '' }}
-    # Groups the Behat legs by PHP version, so the run view shows one collapsible
-    # entry per version instead of a single flat list of 41 jobs.
-    name: Behat | PHP ${{ matrix.php }}
+    # Static on purpose. At this nesting depth the run view does not surface this
+    # name, so putting distinguishing detail here would hide it; the called
+    # workflow carries the full leg name instead.
+    name: Behat
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.functional) }}

--- a/.github/workflows/reusable-unit.yml
+++ b/.github/workflows/reusable-unit.yml
@@ -20,9 +20,10 @@ permissions:
 
 jobs:
   unit:
-    # The calling job already states "Unit | PHP x" and groups on it, so this only
-    # needs to identify the leg within that group.
-    name: PHPUnit${{ inputs.coverage && ' (with coverage)' || '' }}${{ startsWith( inputs.os, 'windows' ) && ' (Windows)' || '' }}${{ startsWith( inputs.os, 'macos' ) && ' (macOS)' || '' }}
+    # This name has to stand on its own. The run view labels a nested job with its
+    # own name only; the calling job's name is not surfaced at this depth, so
+    # anything omitted here is not shown anywhere.
+    name: Unit | PHP ${{ inputs.php }}${{ inputs.coverage && ' (with coverage)' || '' }}${{ startsWith( inputs.os, 'windows' ) && ' (Windows)' || '' }}${{ startsWith( inputs.os, 'macos' ) && ' (macOS)' || '' }}
     # Repositories can point the default Linux legs at a larger runner by setting
     # the `RUNNERS_NAME` repository variable, without having to fork this workflow.
     # Explicit macOS/Windows legs are unaffected.


### PR DESCRIPTION
Fixes a regression from #274. Because consumer repositories pin `@main`, the bad names are live everywhere right now.

## What broke

#274 moved the PHP version out of the called workflows and into the calling job, on the assumption that the run view renders a nested job as `<calling job> / <called job>`. It does not at this depth — a nested job is labelled with its own name only. The version was not moved, it was hidden.

Observed in [wp-cli/wp-cli-tests run 31163465254](https://github.com/wp-cli/wp-cli-tests/actions/runs/31163465254): nine jobs all called `PHPUnit`, and Behat legs called `WP trunk | SQLite` with no way to tell PHP 8.3 from 8.4 from 8.5.

## Why the grouping is not reachable here

The idea came from `wp-cli/automated-tests`, where the run groups neatly by package. That works because its matrix job is called directly from the top-level workflow — two levels, so the matrix job *is* the top-level caller and its name becomes the group header.

This repository has three levels: `testing.yml` → `reusable-testing.yml` → `reusable-unit.yml` / `reusable-functional.yml`. The middle name is not surfaced. Grouping by PHP version would require the matrix to live in each repository's `testing.yml` — the per-repository file that carries `minimum-php`, `minimum-wp` and the `matrix` overrides, and which we deliberately kept out of the sync list. So it is not reachable without reopening that decision.

What actually makes `automated-tests` readable is not the grouping, it is that its leaf name is self-sufficient. That is the property #274 broke.

## This change

- Full description restored in `reusable-unit.yml` and `reusable-functional.yml`, where it is displayed.
- Calling job names in `reusable-testing.yml` static again (`Unit`, `Behat`), with a comment recording why detail must not go there.
- The database version stays spelled out. That part of #274 fixed a real ambiguity: `MySQL` alone rendered the mysql-5.6, 5.7, 8.0 and 8.4 legs identically, which was seven pairs of check runs sharing a name.

Verified by simulating the rendered names across the full pull request matrix: 41 Behat and 9 unit names, no duplicates.

Net effect against `main`: names return to the pre-#274 format, plus the database version disambiguation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jy4dmjymj9VmoTBaqrV4iX)_