### PR TITLE
Fix triage: unusable model pin, and a sweep that cannot see pull requests

### DIFF
--- a/.github/workflows/reusable-issue-triage.yml
+++ b/.github/workflows/reusable-issue-triage.yml
@@ -84,6 +84,12 @@ jobs:
           ITEM_BODY: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.body || github.event.issue.body }}
           ITEM_TYPE: ${{ github.event_name == 'pull_request_target' && 'pull request' || 'issue' }}
         with:
+          # `actions/ai-inference` defaults this to `gpt-4.1`, which Copilot no
+          # longer offers - the CLI rejects it outright and the step fails on
+          # every run. `auto` lets Copilot pick, so a model being retired
+          # cannot break triage again. Pin a specific model here only if a
+          # future prompt needs one, and expect to maintain it when it ages out.
+          model: auto
           prompt: |
             ## Role
 
@@ -368,6 +374,12 @@ jobs:
           ITEM_BODY: ${{ fromJSON(steps.get-item.outputs.result).body }}
           ITEM_TYPE: ${{ fromJSON(steps.get-item.outputs.result).type }}
         with:
+          # `actions/ai-inference` defaults this to `gpt-4.1`, which Copilot no
+          # longer offers - the CLI rejects it outright and the step fails on
+          # every run. `auto` lets Copilot pick, so a model being retired
+          # cannot break triage again. Pin a specific model here only if a
+          # future prompt needs one, and expect to maintain it when it ages out.
+          model: auto
           prompt: |
             ## Role
 

--- a/.github/workflows/reusable-issue-triage.yml
+++ b/.github/workflows/reusable-issue-triage.yml
@@ -220,6 +220,12 @@ jobs:
     permissions:
       actions: write
       issues: read
+      # `listForRepo` below returns issues *and* pull requests, but the pull
+      # requests are filtered out of the response unless the token can read
+      # them - silently, as an empty list rather than an error. Without this
+      # the job reports "Found 0 open issues and PRs" in a repository whose
+      # open items are all pull requests, and triages nothing.
+      pull-requests: read
       contents: read
     steps:
       - name: Find and dispatch triage for unlabeled items


### PR DESCRIPTION
Two independent bugs, both of which have to be fixed before triage works end to end. Neither was introduced by the v3 upgrade in #279.

## 1. Triage fails on every run — an unavailable model

Every triage run since #279 has failed. The Copilot CLI's stderr is routed to debug-only logging by `actions/ai-inference`, so the reason was invisible until [the job was re-run with debug logging](https://github.com/wp-cli/.github/actions/runs/31708855848/job/94479044546):

```
##[debug]Copilot CLI stderr: Error: Model "gpt-4.1" from --model flag is not available.
```

`gpt-4.1` is the action's own default for its `model` input, so the workflow inherited it without ever naming it. Copilot no longer offers that model and the CLI rejects it outright.

Setting `model: auto` — the CLI's documented value for letting Copilot choose — fixes the failure and stops the next model retirement from breaking triage the same way.

**This also settles the authentication question.** Run unauthenticated, the CLI fails with `No authentication information found` *before* it validates the model. This run got the model error instead, which means the token was accepted: `GITHUB_TOKEN` plus `copilot-requests: write` authenticates, the organization policy is enabled, and no PAT is required.

## 2. The unlabeled sweep silently sees nothing

Dispatching with an empty `issue_number` reports `Found 0 open issues and PRs` and triages nothing, while unlabeled pull requests such as #277 sit untouched. Reproduced in [run 31708383158](https://github.com/wp-cli/.github/actions/runs/31708383158/job/94474654706).

The count is zero *in total*, not zero after filtering — the listing itself comes back empty. `issues.listForRepo` returns issues and pull requests together, but pull requests are dropped when the token cannot read them, silently: a shorter list, not an error. This repository has no open issues, so the sweep saw nothing at all and exited 0 with `No unlabeled items to process`, which is why it never showed up as a failing check.

| | `triage-unlabeled-items` permissions | Sees PRs |
| --- | --- | --- |
| Before #275 | no job-level block; inherits workflow-level `pull-requests: write` | yes |
| 93855f4 (#275, Aug 7) onward | own block: `actions: write`, `issues: read`, `contents: read` | no |

#275 scoped `actions: write` down to the one job needing it, which was right, but the new job-level block replaced the inherited permissions wholesale and `pull-requests` was not carried over. Granting `pull-requests: read` restores what the job saw before, and stays read-only — the sweep only reads and dispatches; label writes happen in the jobs it dispatches to.

## Verification

actionlint passes. Behavioural checks, both of which need this merged first, since `issue-triage.yml` resolves the reusable workflow at `@main` regardless of the ref it is dispatched from:

- Open any issue or pull request; the triage run should now reach the model and apply labels.
- Dispatch with an empty `issue_number`; the count should be non-zero.

## Known remaining issue, not fixed here

`triage-single-item` reads `context.issue.number` in its "Get item details" step, but a `workflow_dispatch` payload has no `issue`, `pull_request` or `number`, so it resolves to `undefined`. The apply step in the same job correctly uses `inputs.issue_number`. That means the runs the sweep dispatches will still fail at that step. Introduced in a482e38 (Apr 22), left alone here to keep this change reviewable.