### PR TITLE
Read the dispatched item number from the workflow input

### DIFF
--- a/.github/workflows/reusable-issue-triage.yml
+++ b/.github/workflows/reusable-issue-triage.yml
@@ -329,13 +329,22 @@ jobs:
       - name: Get item details
         id: get-item
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # This job only ever runs on `workflow_dispatch`, and that payload
+          # carries no issue, no pull request and no number - so
+          # `context.issue.number` resolves to `undefined` here and the lookup
+          # below 404s. The number arrives as a workflow input instead, which
+          # is what the apply job downstream already reads.
+          ITEM_NUMBER: ${{ inputs.issue_number }}
         with:
           script: |
+            const itemNumber = parseInt(process.env.ITEM_NUMBER);
+
             // Try to get as an issue first (works for both issues and PRs)
             const issue = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: itemNumber,
             });
 
             const itemType = issue.data.pull_request ? 'pull request' : 'issue';


### PR DESCRIPTION
`triage-single-item` has failed on every dispatch since a482e38 (Apr 22). It is the last of the three bugs that stood between the triage workflow and working end to end; #280 fixed the other two.

## The bug

The job is gated to `workflow_dispatch`:

```yaml
if: |
  github.event_name == 'workflow_dispatch' &&
  inputs.issue_number != ''
```

but its "Get item details" step looked the item up with `context.issue.number`. github-script derives that from the event payload — `payload.issue`, else `payload.pull_request`, else `payload` — and a `workflow_dispatch` payload has none of the three. It resolves to `undefined`, and `issues.get` 404s.

Because the job is dispatch-only, this is not an edge case: the lookup could never have succeeded. Every run of the single-item path failed at step two, which includes every run the unlabeled sweep dispatches — so the sweep would have gone on producing nothing even after #280 taught it to find pull requests.

## The fix

The number is already passed as the `issue_number` workflow input, and the apply job downstream reads it from the environment. This step now does the same, so both halves of the job agree on where the number comes from.

## Scope

The other `context.issue.number` in this file, in `apply-new-item-labels`, is correct and is left alone: that job `needs: triage-new-item`, which runs only on `issues` and `pull_request_target`, and those payloads do carry a number. I checked every use in the file rather than only the one that failed.

## Verification

actionlint passes. The behavioural check needs this on `main` first, since `issue-triage.yml` resolves the reusable workflow at `@main` regardless of the ref it is dispatched from — dispatch with an `issue_number` and the run should reach the model and apply labels, rather than failing at "Get item details".

Note that the repository currently has no open unlabeled items, so an empty-`issue_number` sweep will legitimately report `Found 0` and is not a useful test of this. Dispatch with an explicit number instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdDrWtq6hWWuDDQDxQx94G)_